### PR TITLE
Receive when publish completes

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "cSpell.words": [
+        "CONNACK",
+        "eventloop",
+        "oneshot"
+    ]
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,6 +97,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "env_logger"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
+dependencies = [
+ "humantime",
+ "is-terminal",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
 name = "flume"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -168,6 +181,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "humantime"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+
+[[package]]
 name = "io-uring"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -176,6 +201,17 @@ dependencies = [
  "bitflags",
  "cfg-if",
  "libc",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -259,8 +295,10 @@ dependencies = [
 
 [[package]]
 name = "mqttier"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
+ "env_logger",
+ "log",
  "rumqttc",
  "serde",
  "serde_json",
@@ -367,6 +405,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "regex"
+version = "1.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d7fd106d8c02486a8d64e778353d1cffe08ce79ac2e82f540c86d0facf6912"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -635,6 +685,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -866,6 +925,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqttier"
-version = "0.1.3"
+version = "0.2.0"
 edition = "2024"
 
 [dependencies]
@@ -8,10 +8,11 @@ rumqttc = "0.24"
 tokio = { version = "1.0", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+log = "0.4"
 tracing = "0.1"
 uuid = { version = "1.0", features = ["v4"] }
 thiserror = "1.0"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+env_logger = "0.10"
 
 [dev-dependencies]
-
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ use rumqttc::v5::mqttbytes::v5::{PublishProperties, SubscribeProperties, Packet}
 use rumqttc::v5::mqttbytes::{QoS};
 use serde::Serialize;
 use thiserror::Error;
-use tokio::sync::{mpsc, Mutex, RwLock};
+use tokio::sync::{mpsc, oneshot, Mutex, RwLock};
 use uuid::Uuid;
 
 /// Errors that can occur when using MqttierClient
@@ -33,6 +33,20 @@ pub enum MqttierError {
 
 type Result<T> = std::result::Result<T, MqttierError>;
 
+/// Result of a publish operation indicating when message was acknowledged by broker
+#[derive(Debug)]
+pub enum PublishResult {
+    /// Message was acknowledged by broker (QoS 1 PUBACK or QoS 2 PUBCOMP)
+    Acknowledged,
+    /// Message was received by broker (QoS 2 PUBREC)
+    Received,
+    /// No acknowledgment expected (QoS 0)
+    Sent,
+}
+
+/// Completion signal for a published message
+type PublishCompletion = oneshot::Sender<Result<PublishResult>>;
+
 /// Represents a queued subscription
 #[derive(Debug, Clone)]
 struct QueuedSubscription {
@@ -42,13 +56,14 @@ struct QueuedSubscription {
 }
 
 /// Represents a queued message to publish
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 struct QueuedMessage {
     topic: String,
     payload: Vec<u8>,
     qos: QoS,
     retain: bool,
     publish_props: PublishProperties,
+    completion: Option<PublishCompletion>,
 }
 
 /// A message received from a subscription
@@ -70,6 +85,8 @@ struct ClientState {
     subscriptions: HashMap<usize, mpsc::Sender<ReceivedMessage>>,
     queued_subscriptions: Vec<QueuedSubscription>,
     queued_messages: Vec<QueuedMessage>,
+    publish_queue_tx: Option<mpsc::Sender<QueuedMessage>>,
+    pending_publishes: std::collections::VecDeque<(QoS, Option<PublishCompletion>)>, // Queue of pending publish completions
 }
 
 impl Default for ClientState {
@@ -79,6 +96,8 @@ impl Default for ClientState {
             subscriptions: HashMap::new(),
             queued_subscriptions: Vec::new(),
             queued_messages: Vec::new(),
+            publish_queue_tx: None,
+            pending_publishes: std::collections::VecDeque::new(),
         }
     }
 }
@@ -173,12 +192,47 @@ impl MqttierClient {
     /// * `topic` - The topic to publish to
     /// * `message` - The message to publish (must be serializable)
     /// * `qos` - The QoS level for the message
-    pub async fn publish(&self, topic: String, payload: Vec<u8>, qos: QoS , retain: bool, publish_props: Option<PublishProperties>) -> Result<()> {
+    /// 
+    /// # Returns
+    /// 
+    /// Returns a receiver that will be notified when the message is acknowledged by the broker
+    pub async fn publish(&self, topic: String, payload: Vec<u8>, qos: QoS , retain: bool, publish_props: Option<PublishProperties>) -> Result<oneshot::Receiver<Result<PublishResult>>> {
         let mut state = self.state.write().await;
         let publish_props = publish_props.unwrap_or_default();
+        let (completion_tx, completion_rx) = oneshot::channel();
+        
+        let completion = match qos {
+            QoS::AtMostOnce => {
+                // QoS 0 doesn't need acknowledgment
+                let _ = completion_tx.send(Ok(PublishResult::Sent));
+                None
+            }
+            _ => Some(completion_tx)
+        };
+        
         if state.is_connected {
-            debug!("Publishing message to topic: {} with QoS: {:?}", topic, qos);
-            self.client.publish_with_properties(&topic, qos, retain, payload, publish_props).await?;
+            // If we have a publish queue, send through that
+            if let Some(ref publish_queue_tx) = state.publish_queue_tx {
+                debug!("Sending message to publish queue for topic: {} with QoS: {:?}", topic, qos);
+                let message = QueuedMessage {
+                    topic,
+                    payload,
+                    qos,
+                    retain,
+                    publish_props,
+                    completion,
+                };
+                if let Err(_) = publish_queue_tx.send(message).await {
+                    return Err(MqttierError::ChannelSendError);
+                }
+            } else {
+                // Fallback to direct publish (shouldn't happen in normal operation)
+                debug!("Publishing message directly to topic: {} with QoS: {:?}", topic, qos);
+                self.client.publish_with_properties(&topic, qos, retain, payload, publish_props).await?;
+                if let Some(completion) = completion {
+                    let _ = completion.send(Ok(PublishResult::Sent));
+                }
+            }
         } else {
             debug!("Queueing message for topic: {} with QoS: {:?}", topic, qos);
             state.queued_messages.push(QueuedMessage {
@@ -187,10 +241,11 @@ impl MqttierClient {
                 qos,
                 retain,
                 publish_props,
+                completion,
             });
         }
 
-        Ok(())
+        Ok(completion_rx)
     }
 
     /// Publish a string message to a topic
@@ -202,6 +257,10 @@ impl MqttierClient {
     /// * `qos` - The QoS level for the message (0, 1, or 2)
     /// * `retain` - Whether to retain the message
     /// * `publish_props` - Optional publish properties
+    /// 
+    /// # Returns
+    /// 
+    /// Returns a receiver that will be notified when the message is acknowledged by the broker
     pub async fn publish_string(
         &self,
         topic: String,
@@ -209,7 +268,7 @@ impl MqttierClient {
         qos: u8,
         retain: bool,
         publish_props: Option<PublishProperties>,
-    ) -> Result<()> {
+    ) -> Result<oneshot::Receiver<Result<PublishResult>>> {
         let rumqttc_qos = match qos {
             0 => QoS::AtMostOnce,
             1 => QoS::AtLeastOnce,
@@ -226,11 +285,15 @@ impl MqttierClient {
     /// * `topic` - The topic to publish to
     /// * `payload` - The serializable struct to send as payload
     /// * `state_version` - The version of the structure
+    /// 
+    /// # Returns
+    /// 
+    /// Returns a receiver that will be notified when the message is acknowledged by the broker
     pub async fn publish_structure<T: Serialize>(
         &self,
         topic: String,
         payload: T,
-    ) -> Result<()> {
+    ) -> Result<oneshot::Receiver<Result<PublishResult>>> {
         let mut props = PublishProperties::default();
         props.content_type = Some("application/json".to_string());
         let payload_bytes = serde_json::to_vec(&payload)?;
@@ -245,13 +308,17 @@ impl MqttierClient {
     /// * `payload` - The serializable struct to send as payload
     /// * `response_topic` - The topic where responses should be sent
     /// * `correlation_id` - The correlation id for matching responses
+    /// 
+    /// # Returns
+    /// 
+    /// Returns a receiver that will be notified when the message is acknowledged by the broker
     pub async fn publish_request<T: Serialize>(
         &self,
         topic: String,
         payload: T,
         response_topic: String,
         correlation_id: Vec<u8>,
-    ) -> Result<()> {
+    ) -> Result<oneshot::Receiver<Result<PublishResult>>> {
         let mut props = PublishProperties::default();
         props.response_topic = Some(response_topic);
         props.correlation_data = Some(correlation_id.into());
@@ -267,12 +334,16 @@ impl MqttierClient {
     /// * `topic` - The topic to publish to
     /// * `payload` - The serializable struct to send as payload
     /// * `correlation_id` - The correlation id for matching requests
+    /// 
+    /// # Returns
+    /// 
+    /// Returns a receiver that will be notified when the message is acknowledged by the broker
     pub async fn publish_response<T: Serialize>(
         &self,
         topic: String,
         payload: T,
         correlation_id: Vec<u8>,
-    ) -> Result<()> {
+    ) -> Result<oneshot::Receiver<Result<PublishResult>>> {
         let mut props = PublishProperties::default();
         props.content_type = Some("application/json".to_string());
         props.correlation_data = Some(correlation_id.into());
@@ -286,12 +357,16 @@ impl MqttierClient {
     /// 
     /// * `topic` - The topic to publish to
     /// * `payload` - The serializable struct to send as payload
+    /// 
+    /// # Returns
+    /// 
+    /// Returns a receiver that will be notified when the message is acknowledged by the broker
     pub async fn publish_state<T: Serialize>(
         &self,
         topic: String,
         payload: T,
         state_version: u32,
-    ) -> Result<()> {
+    ) -> Result<oneshot::Receiver<Result<PublishResult>>> {
         let mut props = PublishProperties::default();
         props.user_properties.push((
             "PropertyVersion".to_string(),
@@ -313,10 +388,27 @@ impl MqttierClient {
         *is_running = true;
         drop(is_running);
 
+        // Create publish queue
+        let (publish_queue_tx, publish_queue_rx) = mpsc::channel::<QueuedMessage>(100);
+        
+        // Set up the publish queue in state
+        {
+            let mut state = self.state.write().await;
+            state.publish_queue_tx = Some(publish_queue_tx);
+        }
+
         let client = self.client.clone();
         let state = self.state.clone();
         let eventloop = self.eventloop.clone();
 
+        // Start the publish loop
+        let client_for_publish = client.clone();
+        let state_for_publish = state.clone();
+        tokio::spawn(async move {
+            Self::publish_loop(client_for_publish, state_for_publish, publish_queue_rx).await;
+        });
+
+        // Start the connection loop
         tokio::spawn(async move {
             loop {
                 info!("Starting MQTT connection loop");
@@ -354,6 +446,51 @@ impl MqttierClient {
         Ok(())
     }
 
+    /// Handle the publish loop - processes queued messages and waits for acknowledgments
+    async fn publish_loop(
+        client: AsyncClient,
+        state: Arc<RwLock<ClientState>>,
+        mut publish_queue_rx: mpsc::Receiver<QueuedMessage>,
+    ) {
+        info!("Starting publish loop");
+        
+        while let Some(message) = publish_queue_rx.recv().await {
+            debug!("Publishing message to topic: {} with QoS: {:?}", message.topic, message.qos);
+            
+            match client.publish_with_properties(
+                &message.topic, 
+                message.qos, 
+                message.retain, 
+                message.payload, 
+                message.publish_props
+            ).await {
+                Ok(()) => {
+                    match message.qos {
+                        QoS::AtMostOnce => {
+                            // QoS 0 - no acknowledgment expected, complete immediately
+                            if let Some(completion) = message.completion {
+                                let _ = completion.send(Ok(PublishResult::Sent));
+                            }
+                        }
+                        QoS::AtLeastOnce | QoS::ExactlyOnce => {
+                            // QoS 1 and 2 - add to shared pending queue for acknowledgment handling
+                            let mut state_guard = state.write().await;
+                            state_guard.pending_publishes.push_back((message.qos, message.completion));
+                        }
+                    }
+                }
+                Err(e) => {
+                    error!("Failed to publish message: {}", e);
+                    if let Some(completion) = message.completion {
+                        let _ = completion.send(Err(MqttierError::ClientError(e)));
+                    }
+                }
+            }
+        }
+        
+        info!("Publish loop ended");
+    }
+
     /// Handle a single MQTT connection
     async fn handle_connection(
         client: &AsyncClient,
@@ -386,13 +523,18 @@ impl MqttierClient {
 
                     // Process queued messages
                     let s = state.clone();
-                    let c = client.clone();
                     tokio::spawn(async move {
                         let mut state_guard = s.write().await;
+                        let publish_queue_tx = state_guard.publish_queue_tx.clone();
                         for message in state_guard.queued_messages.drain(..) {
                             debug!("Processing queued message for topic: {}", message.topic);
-                            let x = c.publish_with_properties(&message.topic, message.qos, message.retain, message.payload, message.publish_props).await;
-                            info!("Publish result {}: {:?}", message.topic, x);
+                            if let Some(ref tx) = publish_queue_tx {
+                                if let Err(_) = tx.send(message).await {
+                                    error!("Failed to send queued message to publish queue");
+                                }
+                            } else {
+                                error!("No publish queue available for queued messages");
+                            }
                         }
                     });
                 }
@@ -428,11 +570,40 @@ impl MqttierClient {
                         }
                     }
                 }
+                Ok(Event::Incoming(Packet::PubAck(puback))) => {
+                    debug!("Received PUBACK for packet ID: {}", puback.pkid);
+                    let mut state_guard = state.write().await;
+                    if let Some((_qos, completion_opt)) = state_guard.pending_publishes.pop_front() {
+                        if let Some(completion) = completion_opt {
+                            let _ = completion.send(Ok(PublishResult::Acknowledged));
+                        }
+                    }
+                }
+                Ok(Event::Incoming(Packet::PubRec(pubrec))) => {
+                    debug!("Received PUBREC for packet ID: {}", pubrec.pkid);
+                    let mut state_guard = state.write().await;
+                    if let Some((_qos, completion_opt)) = state_guard.pending_publishes.pop_front() {
+                        if let Some(completion) = completion_opt {
+                            let _ = completion.send(Ok(PublishResult::Received));
+                        }
+                    }
+                }
+                Ok(Event::Incoming(Packet::PubComp(pubcomp))) => {
+                    debug!("Received PUBCOMP for packet ID: {}", pubcomp.pkid);
+                    let mut state_guard = state.write().await;
+                    if let Some((_qos, completion_opt)) = state_guard.pending_publishes.pop_front() {
+                        if let Some(completion) = completion_opt {
+                            let _ = completion.send(Ok(PublishResult::Acknowledged));
+                        }
+                    }
+                }
                 Ok(Event::Incoming(packet)) => {
                     debug!("Received packet: {:?}", packet);
                 }
-                Ok(Event::Outgoing(_)) => {
-                    // Outgoing events don't need special handling
+                Ok(Event::Outgoing(outgoing)) => {
+                    debug!("Outgoing event: {:?}", outgoing);
+                    // Outgoing events can be used to track when messages are sent
+                    // For now, we'll just log them
                 }
                 Err(e) => {
                     error!("Event loop error: {}", e);


### PR DESCRIPTION
When the publish operation is complete (differs depending on QoS) a return oneshot receives the packet id.